### PR TITLE
Update 10_Cluster_health.md

### DIFF
--- a/020_Distributed_Cluster/10_Cluster_health.md
+++ b/020_Distributed_Cluster/10_Cluster_health.md
@@ -32,4 +32,4 @@ GET /_cluster/health
 | `yellow` | 所有主分片可用，但不是所有复制分片都可用 |
 | `red`    | 不是所有的主分片都可用                   |
 
-在接下来的章节，我们将说明什么是**主要分片(primary shared)**和**复制分片(replica shards)**，并说明这些颜色在实际环境中的意义。
+在接下来的章节，我们将说明什么是**主要分片(primary shard)**和**复制分片(replica shard)**，并说明这些颜色在实际环境中的意义。


### PR DESCRIPTION
最后一句在
https://github.com/elasticsearch/elasticsearch-definitive-guide/blob/master/020_Distributed_Cluster/10_Cluster_health.asciidoc
的原文是：
In the rest of this chapter we explain what primary and replica shards are and explain the practical implications of each of the above colors.
个人认为翻译时注释都用单数即可，另外改了个拼写错误。
