### PR TITLE
Update 30_Tutorial_Search.md

### DIFF
--- a/010_Intro/30_Tutorial_Search.md
+++ b/010_Intro/30_Tutorial_Search.md
@@ -160,16 +160,16 @@ GET /megacorp/employee/_search
 ```Javascript
 GET /megacorp/employee/_search
 {
-    "query" : {
-        "filtered" : {
-            "filter" : {
-                "range" : {
-                    "age" : { "gt" : 30 } <1>
+   "query": {
+        "bool": {
+            "must": {
+                "match": {
+                    "last_name": "smith"    <1>
                 }
             },
-            "query" : {
-                "match" : {
-                    "last_name" : "smith" <2>
+            "filter": {
+                "range": {
+                    "age": { "gt": 30 }     <2>
                 }
             }
         }


### PR DESCRIPTION
es5 remove `filtered` query is replaced by the [bool](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/query-dsl-bool-query.html) query. Instead of the following